### PR TITLE
Add 0 pockets check to work w/ enspara update

### DIFF
--- a/analysis/pockets.py
+++ b/analysis/pockets.py
@@ -44,7 +44,15 @@ def _save_pocket_element(save_info):
     # make state analysis directory and save pdb coords
     _ = tools.run_commands('mkdir ' + output_folder)
     pok_output_name = output_folder + "/" + state_name + "_pockets.pdb"
-    pocket_element.save_pdb(pok_output_name)
+
+    if pocket_element is None:
+        #Recent update to enspara returns None for no pockets instead of empty MDtraj traj
+        pocket_element=md.Trajectory(np.zeros((0,3)),md.Topology())
+        pocket_element.save_pdb(pok_output_name)
+
+    else:    
+        pocket_element.save_pdb(pok_output_name)
+
     # generate pocket size array (first element is the total size)
     pok_sizes = np.array(
         [len(list(resi.atoms)) for resi in list(pocket_element.top.residues)])


### PR DESCRIPTION
This commit in `enspara`:
https://github.com/bowman-lab/enspara/commit/c0197066e025a8bfe0b760e45b473201690f5347

switched `enspara/geometry/pockets.py` to returning `None` if there are no pockets found in a structure as opposed to an empty MDTraj object. Accordingly, when the pocket structures are saved, FAST throws an error and quits, error trace at the end of this issue. 

This PR implements a check to see if `enspara/geometry/pockets.py` is returning `None` and if so instead creates and saves an empty MDTraj object. Implemented code successfully bypasses the `None` error documented below.


Error trace (from FAST w/ a centers file that has 0 pockets)-

```
Traceback (most recent call last):
  File "/home/justinjm/miniconda3/envs/enspara/lib/python3.6/multiprocessing/pool.py", line 119, in worker
    result = (True, func(*args, **kwds))
  File "/home/justinjm/miniconda3/envs/enspara/lib/python3.6/multiprocessing/pool.py", line 44, in mapstar
    return list(map(*args))
  File "/export/seas-home/justinjm/software/fast/analysis/pockets.py", line 47, in _save_pocket_element
    pocket_element.save_pdb(pok_output_name)
AttributeError: 'NoneType' object has no attribute 'save_pdb'
"""

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "analysis.py", line 4, in <module>
    c.run()
  File "/export/seas-home/justinjm/software/fast/analysis/pockets.py", line 283, in run
    self.output_folder, self.n_cpus)
  File "/export/seas-home/justinjm/software/fast/analysis/pockets.py", line 72, in save_pocket_elements
    pool.map(_save_pocket_element, save_info)
  File "/home/justinjm/miniconda3/envs/enspara/lib/python3.6/multiprocessing/pool.py", line 266, in map
    return self._map_async(func, iterable, mapstar, chunksize).get()
  File "/home/justinjm/miniconda3/envs/enspara/lib/python3.6/multiprocessing/pool.py", line 644, in get
    raise self._value
AttributeError: 'NoneType' object has no attribute 'save_pdb'
```